### PR TITLE
Add environment variables parsing in ec2.ini

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -219,7 +219,7 @@ class Ec2Inventory(object):
         if six.PY3:
             config = configparser.ConfigParser()
         else:
-            config = configparser.SafeConfigParser()
+            config = configparser.SafeConfigParser(os.environ)
         ec2_default_ini_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ec2.ini')
         ec2_ini_path = os.path.expanduser(os.path.expandvars(os.environ.get('EC2_INI_PATH', ec2_default_ini_path)))
         config.read(ec2_ini_path)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ec2.py 
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = /home/aws-ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

ec2.py was unable to pick ec2.ini with environment variables. This will enable it to pick environment variables where needed. 

One use case is if we need to filter the returned host list with a particular tag name which is defined in the environment. 

```
pattern_include = %(AWS_PROFILE)s_
```

AWS_PROFILE is already defined and being used in other parts of the system. 

This enables to use the same AWS Account for multiple environments like sandbox, test, staging etc without mixing up the nodes. 

Use Case: ec2.ini pattern_include needs an environment variable
